### PR TITLE
chore: clean up secrets created by sample tests

### DIFF
--- a/samples/snippets/snippets_test.py
+++ b/samples/snippets/snippets_test.py
@@ -69,6 +69,7 @@ def secret_id(client, project_id):
         client.delete_secret(request={"name": secret_path})
     except exceptions.NotFound:
         # Secret was already deleted, probably in the test
+        print(f"Secret {secret_id} was not found.")
         pass
 
 

--- a/samples/snippets/snippets_test.py
+++ b/samples/snippets/snippets_test.py
@@ -88,9 +88,6 @@ def secret(client, project_id, secret_id):
     yield project_id, secret_id, secret.etag
 
 
-another_secret = secret
-
-
 @pytest.fixture()
 def secret_version(client, secret):
     project_id, secret_id, _ = secret
@@ -230,14 +227,12 @@ def test_list_secret_versions(capsys, secret_version, another_secret_version):
     assert another_version_id in out
 
 
-def test_list_secrets(capsys, secret, another_secret):
+def test_list_secrets(capsys, secret):
     project_id, secret_id, _ = secret
-    _, another_secret_id, _ = another_secret
     list_secrets(project_id)
 
     out, _ = capsys.readouterr()
     assert secret_id in out
-    assert another_secret_id in out
 
 
 def test_update_secret(secret):

--- a/samples/snippets/snippets_test.py
+++ b/samples/snippets/snippets_test.py
@@ -58,11 +58,25 @@ def iam_user():
 
 
 @pytest.fixture()
-def secret(client, project_id):
-    parent = f"projects/{project_id}"
+def secret_id(client, project_id):
     secret_id = "python-secret-{}".format(uuid.uuid4())
 
+    yield secret_id
+
+    secret_path = client.secret_path(project_id, secret_id)
+    print("deleting secret {}".format(secret_id))
+    try:
+        client.delete_secret(request={"name": secret_path})
+    except exceptions.NotFound:
+        # Secret was already deleted, probably in the test
+        pass
+
+
+@pytest.fixture()
+def secret(client, project_id, secret_id):
     print("creating secret {}".format(secret_id))
+
+    parent = f"projects/{project_id}"
     secret = client.create_secret(
         request={
             "parent": parent,
@@ -72,13 +86,6 @@ def secret(client, project_id):
     )
 
     yield project_id, secret_id, secret.etag
-
-    print("deleting secret {}".format(secret_id))
-    try:
-        client.delete_secret(request={"name": secret.name})
-    except exceptions.NotFound:
-        # Secret was already deleted, probably in the test
-        pass
 
 
 another_secret = secret
@@ -107,13 +114,15 @@ def pubsub_message():
     message_bytes = message.encode()
     base64_bytes = base64.b64encode(message_bytes)
     return {
-        "attributes": {"eventType": "SECRET_UPDATE", "secretId": "projects/p/secrets/s"},
-        "data": base64_bytes
+        "attributes": {
+            "eventType": "SECRET_UPDATE",
+            "secretId": "projects/p/secrets/s",
+        },
+        "data": base64_bytes,
     }
 
 
-def test_quickstart(project_id):
-    secret_id = "python-secret-{}".format(uuid.uuid4())
+def test_quickstart(project_id, secret_id):
     quickstart(project_id, secret_id)
 
 
@@ -130,11 +139,9 @@ def test_add_secret_version(secret):
     assert secret_id in version.name
 
 
-def test_create_secret(client, project_id):
-    secret_id = "python-secret-{}".format(uuid.uuid4())
+def test_create_secret(client, project_id, secret_id):
     secret = create_secret(project_id, secret_id)
     assert secret_id in secret.name
-    client.delete_secret(request={"name": secret.name})
 
 
 def test_delete_secret(client, secret):
@@ -181,7 +188,9 @@ def test_enable_disable_secret_version_with_etag(client, secret_version):
     version = disable_secret_version_with_etag(project_id, secret_id, version_id, etag)
     assert version.state == secretmanager.SecretVersion.State.DISABLED
 
-    version = enable_secret_version_with_etag(project_id, secret_id, version_id, version.etag)
+    version = enable_secret_version_with_etag(
+        project_id, secret_id, version_id, version.etag
+    )
     assert version.state == secretmanager.SecretVersion.State.ENABLED
 
 
@@ -239,7 +248,9 @@ def test_update_secret(secret):
 
 def test_consume_event_notification(pubsub_message):
     got = consume_event_notification(pubsub_message, None)
-    assert got == "Received SECRET_UPDATE for projects/p/secrets/s. New metadata: hello!"
+    assert (
+        got == "Received SECRET_UPDATE for projects/p/secrets/s. New metadata: hello!"
+    )
 
 
 def test_update_secret_with_etag(secret):


### PR DESCRIPTION
Fixes #177.

The `quickstart` and `create_secret` tests were not cleaning up secrets. I created an additional `secret_id` fixture that  generates an id, yields the id, then cleans up the secret. 

I had trouble getting two different secrets to `list_secrets` so I removed the second secret.