### PR TITLE
fix: add 'dict' type annotation to 'request'

### DIFF
--- a/google/cloud/secretmanager_v1/services/secret_manager_service/async_client.py
+++ b/google/cloud/secretmanager_v1/services/secret_manager_service/async_client.py
@@ -183,7 +183,7 @@ class SecretManagerServiceAsyncClient:
 
     async def list_secrets(
         self,
-        request: service.ListSecretsRequest = None,
+        request: Union[service.ListSecretsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -193,7 +193,7 @@ class SecretManagerServiceAsyncClient:
         r"""Lists [Secrets][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.ListSecretsRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.ListSecretsRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.ListSecrets][google.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
             parent (:class:`str`):
@@ -265,7 +265,7 @@ class SecretManagerServiceAsyncClient:
 
     async def create_secret(
         self,
-        request: service.CreateSecretRequest = None,
+        request: Union[service.CreateSecretRequest, dict] = None,
         *,
         parent: str = None,
         secret_id: str = None,
@@ -279,7 +279,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.CreateSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.CreateSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.CreateSecret][google.cloud.secretmanager.v1.SecretManagerService.CreateSecret].
             parent (:class:`str`):
@@ -369,7 +369,7 @@ class SecretManagerServiceAsyncClient:
 
     async def add_secret_version(
         self,
-        request: service.AddSecretVersionRequest = None,
+        request: Union[service.AddSecretVersionRequest, dict] = None,
         *,
         parent: str = None,
         payload: resources.SecretPayload = None,
@@ -383,7 +383,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.AddSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.AddSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion].
             parent (:class:`str`):
@@ -456,7 +456,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_secret(
         self,
-        request: service.GetSecretRequest = None,
+        request: Union[service.GetSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -467,7 +467,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.GetSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.GetSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.GetSecret][google.cloud.secretmanager.v1.SecretManagerService.GetSecret].
             name (:class:`str`):
@@ -546,7 +546,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.UpdateSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.UpdateSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.UpdateSecret][google.cloud.secretmanager.v1.SecretManagerService.UpdateSecret].
             secret (:class:`google.cloud.secretmanager_v1.types.Secret`):
@@ -623,7 +623,7 @@ class SecretManagerServiceAsyncClient:
 
     async def delete_secret(
         self,
-        request: service.DeleteSecretRequest = None,
+        request: Union[service.DeleteSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -633,7 +633,7 @@ class SecretManagerServiceAsyncClient:
         r"""Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.DeleteSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.DeleteSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.DeleteSecret][google.cloud.secretmanager.v1.SecretManagerService.DeleteSecret].
             name (:class:`str`):
@@ -688,7 +688,7 @@ class SecretManagerServiceAsyncClient:
 
     async def list_secret_versions(
         self,
-        request: service.ListSecretVersionsRequest = None,
+        request: Union[service.ListSecretVersionsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -700,7 +700,7 @@ class SecretManagerServiceAsyncClient:
         This call does not return secret data.
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.ListSecretVersionsRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.ListSecretVersionsRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.ListSecretVersions][google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
             parent (:class:`str`):
@@ -773,7 +773,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_secret_version(
         self,
-        request: service.GetSecretVersionRequest = None,
+        request: Union[service.GetSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -788,7 +788,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.GetSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.GetSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.GetSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.GetSecretVersion].
             name (:class:`str`):
@@ -854,7 +854,7 @@ class SecretManagerServiceAsyncClient:
 
     async def access_secret_version(
         self,
-        request: service.AccessSecretVersionRequest = None,
+        request: Union[service.AccessSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -870,7 +870,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.AccessSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.AccessSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.AccessSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
             name (:class:`str`):
@@ -946,7 +946,7 @@ class SecretManagerServiceAsyncClient:
 
     async def disable_secret_version(
         self,
-        request: service.DisableSecretVersionRequest = None,
+        request: Union[service.DisableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -963,7 +963,7 @@ class SecretManagerServiceAsyncClient:
         [DISABLED][google.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.DisableSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.DisableSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.DisableSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.DisableSecretVersion].
             name (:class:`str`):
@@ -1026,7 +1026,7 @@ class SecretManagerServiceAsyncClient:
 
     async def enable_secret_version(
         self,
-        request: service.EnableSecretVersionRequest = None,
+        request: Union[service.EnableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1043,7 +1043,7 @@ class SecretManagerServiceAsyncClient:
         [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.EnableSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.EnableSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.EnableSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.EnableSecretVersion].
             name (:class:`str`):
@@ -1106,7 +1106,7 @@ class SecretManagerServiceAsyncClient:
 
     async def destroy_secret_version(
         self,
-        request: service.DestroySecretVersionRequest = None,
+        request: Union[service.DestroySecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1124,7 +1124,7 @@ class SecretManagerServiceAsyncClient:
         and irrevocably destroys the secret data.
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.DestroySecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.DestroySecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.DestroySecretVersion][google.cloud.secretmanager.v1.SecretManagerService.DestroySecretVersion].
             name (:class:`str`):
@@ -1187,7 +1187,7 @@ class SecretManagerServiceAsyncClient:
 
     async def set_iam_policy(
         self,
-        request: iam_policy_pb2.SetIamPolicyRequest = None,
+        request: Union[iam_policy_pb2.SetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1202,7 +1202,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (:class:`google.iam.v1.iam_policy_pb2.SetIamPolicyRequest`):
+            request (Union[google.iam.v1.iam_policy_pb2.SetIamPolicyRequest, dict]):
                 The request object. Request message for `SetIamPolicy`
                 method.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
@@ -1298,7 +1298,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_iam_policy(
         self,
-        request: iam_policy_pb2.GetIamPolicyRequest = None,
+        request: Union[iam_policy_pb2.GetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1309,7 +1309,7 @@ class SecretManagerServiceAsyncClient:
         have a policy set.
 
         Args:
-            request (:class:`google.iam.v1.iam_policy_pb2.GetIamPolicyRequest`):
+            request (Union[google.iam.v1.iam_policy_pb2.GetIamPolicyRequest, dict]):
                 The request object. Request message for `GetIamPolicy`
                 method.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
@@ -1405,7 +1405,7 @@ class SecretManagerServiceAsyncClient:
 
     async def test_iam_permissions(
         self,
-        request: iam_policy_pb2.TestIamPermissionsRequest = None,
+        request: Union[iam_policy_pb2.TestIamPermissionsRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1421,7 +1421,7 @@ class SecretManagerServiceAsyncClient:
         warning.
 
         Args:
-            request (:class:`google.iam.v1.iam_policy_pb2.TestIamPermissionsRequest`):
+            request (Union[google.iam.v1.iam_policy_pb2.TestIamPermissionsRequest, dict]):
                 The request object. Request message for
                 `TestIamPermissions` method.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,

--- a/google/cloud/secretmanager_v1/services/secret_manager_service/async_client.py
+++ b/google/cloud/secretmanager_v1/services/secret_manager_service/async_client.py
@@ -183,7 +183,7 @@ class SecretManagerServiceAsyncClient:
 
     async def list_secrets(
         self,
-        request: Union[service.ListSecretsRequest, dict] = None,
+        request: service.ListSecretsRequest = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -193,7 +193,7 @@ class SecretManagerServiceAsyncClient:
         r"""Lists [Secrets][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1.types.ListSecretsRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1.types.ListSecretsRequest`):
                 The request object. Request message for
                 [SecretManagerService.ListSecrets][google.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
             parent (:class:`str`):
@@ -265,7 +265,7 @@ class SecretManagerServiceAsyncClient:
 
     async def create_secret(
         self,
-        request: Union[service.CreateSecretRequest, dict] = None,
+        request: service.CreateSecretRequest = None,
         *,
         parent: str = None,
         secret_id: str = None,
@@ -279,7 +279,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1.types.CreateSecretRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1.types.CreateSecretRequest`):
                 The request object. Request message for
                 [SecretManagerService.CreateSecret][google.cloud.secretmanager.v1.SecretManagerService.CreateSecret].
             parent (:class:`str`):
@@ -369,7 +369,7 @@ class SecretManagerServiceAsyncClient:
 
     async def add_secret_version(
         self,
-        request: Union[service.AddSecretVersionRequest, dict] = None,
+        request: service.AddSecretVersionRequest = None,
         *,
         parent: str = None,
         payload: resources.SecretPayload = None,
@@ -383,7 +383,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1.types.AddSecretVersionRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1.types.AddSecretVersionRequest`):
                 The request object. Request message for
                 [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion].
             parent (:class:`str`):
@@ -456,7 +456,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_secret(
         self,
-        request: Union[service.GetSecretRequest, dict] = None,
+        request: service.GetSecretRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -467,7 +467,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1.types.GetSecretRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1.types.GetSecretRequest`):
                 The request object. Request message for
                 [SecretManagerService.GetSecret][google.cloud.secretmanager.v1.SecretManagerService.GetSecret].
             name (:class:`str`):
@@ -534,7 +534,7 @@ class SecretManagerServiceAsyncClient:
 
     async def update_secret(
         self,
-        request: Union[service.UpdateSecretRequest, dict] = None,
+        request: service.UpdateSecretRequest = None,
         *,
         secret: resources.Secret = None,
         update_mask: field_mask_pb2.FieldMask = None,
@@ -546,7 +546,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1.types.UpdateSecretRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1.types.UpdateSecretRequest`):
                 The request object. Request message for
                 [SecretManagerService.UpdateSecret][google.cloud.secretmanager.v1.SecretManagerService.UpdateSecret].
             secret (:class:`google.cloud.secretmanager_v1.types.Secret`):
@@ -623,7 +623,7 @@ class SecretManagerServiceAsyncClient:
 
     async def delete_secret(
         self,
-        request: Union[service.DeleteSecretRequest, dict] = None,
+        request: service.DeleteSecretRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -633,7 +633,7 @@ class SecretManagerServiceAsyncClient:
         r"""Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1.types.DeleteSecretRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1.types.DeleteSecretRequest`):
                 The request object. Request message for
                 [SecretManagerService.DeleteSecret][google.cloud.secretmanager.v1.SecretManagerService.DeleteSecret].
             name (:class:`str`):
@@ -688,7 +688,7 @@ class SecretManagerServiceAsyncClient:
 
     async def list_secret_versions(
         self,
-        request: Union[service.ListSecretVersionsRequest, dict] = None,
+        request: service.ListSecretVersionsRequest = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -700,7 +700,7 @@ class SecretManagerServiceAsyncClient:
         This call does not return secret data.
 
         Args:
-            request (Union[google.cloud.secretmanager_v1.types.ListSecretVersionsRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1.types.ListSecretVersionsRequest`):
                 The request object. Request message for
                 [SecretManagerService.ListSecretVersions][google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
             parent (:class:`str`):
@@ -773,7 +773,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_secret_version(
         self,
-        request: Union[service.GetSecretVersionRequest, dict] = None,
+        request: service.GetSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -788,7 +788,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1.types.GetSecretVersionRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1.types.GetSecretVersionRequest`):
                 The request object. Request message for
                 [SecretManagerService.GetSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.GetSecretVersion].
             name (:class:`str`):
@@ -854,7 +854,7 @@ class SecretManagerServiceAsyncClient:
 
     async def access_secret_version(
         self,
-        request: Union[service.AccessSecretVersionRequest, dict] = None,
+        request: service.AccessSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -870,7 +870,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1.types.AccessSecretVersionRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1.types.AccessSecretVersionRequest`):
                 The request object. Request message for
                 [SecretManagerService.AccessSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
             name (:class:`str`):
@@ -946,7 +946,7 @@ class SecretManagerServiceAsyncClient:
 
     async def disable_secret_version(
         self,
-        request: Union[service.DisableSecretVersionRequest, dict] = None,
+        request: service.DisableSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -963,7 +963,7 @@ class SecretManagerServiceAsyncClient:
         [DISABLED][google.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1.types.DisableSecretVersionRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1.types.DisableSecretVersionRequest`):
                 The request object. Request message for
                 [SecretManagerService.DisableSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.DisableSecretVersion].
             name (:class:`str`):
@@ -1026,7 +1026,7 @@ class SecretManagerServiceAsyncClient:
 
     async def enable_secret_version(
         self,
-        request: Union[service.EnableSecretVersionRequest, dict] = None,
+        request: service.EnableSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1043,7 +1043,7 @@ class SecretManagerServiceAsyncClient:
         [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1.types.EnableSecretVersionRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1.types.EnableSecretVersionRequest`):
                 The request object. Request message for
                 [SecretManagerService.EnableSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.EnableSecretVersion].
             name (:class:`str`):
@@ -1106,7 +1106,7 @@ class SecretManagerServiceAsyncClient:
 
     async def destroy_secret_version(
         self,
-        request: Union[service.DestroySecretVersionRequest, dict] = None,
+        request: service.DestroySecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1124,7 +1124,7 @@ class SecretManagerServiceAsyncClient:
         and irrevocably destroys the secret data.
 
         Args:
-            request (Union[google.cloud.secretmanager_v1.types.DestroySecretVersionRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1.types.DestroySecretVersionRequest`):
                 The request object. Request message for
                 [SecretManagerService.DestroySecretVersion][google.cloud.secretmanager.v1.SecretManagerService.DestroySecretVersion].
             name (:class:`str`):
@@ -1187,7 +1187,7 @@ class SecretManagerServiceAsyncClient:
 
     async def set_iam_policy(
         self,
-        request: Union[iam_policy_pb2.SetIamPolicyRequest, dict] = None,
+        request: iam_policy_pb2.SetIamPolicyRequest = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1202,7 +1202,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (Union[google.iam.v1.iam_policy_pb2.SetIamPolicyRequest, dict]):
+            request (:class:`google.iam.v1.iam_policy_pb2.SetIamPolicyRequest`):
                 The request object. Request message for `SetIamPolicy`
                 method.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
@@ -1298,7 +1298,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_iam_policy(
         self,
-        request: Union[iam_policy_pb2.GetIamPolicyRequest, dict] = None,
+        request: iam_policy_pb2.GetIamPolicyRequest = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1309,7 +1309,7 @@ class SecretManagerServiceAsyncClient:
         have a policy set.
 
         Args:
-            request (Union[google.iam.v1.iam_policy_pb2.GetIamPolicyRequest, dict]):
+            request (:class:`google.iam.v1.iam_policy_pb2.GetIamPolicyRequest`):
                 The request object. Request message for `GetIamPolicy`
                 method.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
@@ -1405,7 +1405,7 @@ class SecretManagerServiceAsyncClient:
 
     async def test_iam_permissions(
         self,
-        request: Union[iam_policy_pb2.TestIamPermissionsRequest, dict] = None,
+        request: iam_policy_pb2.TestIamPermissionsRequest = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1421,7 +1421,7 @@ class SecretManagerServiceAsyncClient:
         warning.
 
         Args:
-            request (Union[google.iam.v1.iam_policy_pb2.TestIamPermissionsRequest, dict]):
+            request (:class:`google.iam.v1.iam_policy_pb2.TestIamPermissionsRequest`):
                 The request object. Request message for
                 `TestIamPermissions` method.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,

--- a/google/cloud/secretmanager_v1/services/secret_manager_service/async_client.py
+++ b/google/cloud/secretmanager_v1/services/secret_manager_service/async_client.py
@@ -183,7 +183,7 @@ class SecretManagerServiceAsyncClient:
 
     async def list_secrets(
         self,
-        request: service.ListSecretsRequest = None,
+        request: Union[service.ListSecretsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -193,7 +193,7 @@ class SecretManagerServiceAsyncClient:
         r"""Lists [Secrets][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.ListSecretsRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.ListSecretsRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.ListSecrets][google.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
             parent (:class:`str`):
@@ -265,7 +265,7 @@ class SecretManagerServiceAsyncClient:
 
     async def create_secret(
         self,
-        request: service.CreateSecretRequest = None,
+        request: Union[service.CreateSecretRequest, dict] = None,
         *,
         parent: str = None,
         secret_id: str = None,
@@ -279,7 +279,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.CreateSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.CreateSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.CreateSecret][google.cloud.secretmanager.v1.SecretManagerService.CreateSecret].
             parent (:class:`str`):
@@ -369,7 +369,7 @@ class SecretManagerServiceAsyncClient:
 
     async def add_secret_version(
         self,
-        request: service.AddSecretVersionRequest = None,
+        request: Union[service.AddSecretVersionRequest, dict] = None,
         *,
         parent: str = None,
         payload: resources.SecretPayload = None,
@@ -383,7 +383,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.AddSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.AddSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion].
             parent (:class:`str`):
@@ -456,7 +456,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_secret(
         self,
-        request: service.GetSecretRequest = None,
+        request: Union[service.GetSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -467,7 +467,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.GetSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.GetSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.GetSecret][google.cloud.secretmanager.v1.SecretManagerService.GetSecret].
             name (:class:`str`):
@@ -534,7 +534,7 @@ class SecretManagerServiceAsyncClient:
 
     async def update_secret(
         self,
-        request: service.UpdateSecretRequest = None,
+        request: Union[service.UpdateSecretRequest, dict] = None,
         *,
         secret: resources.Secret = None,
         update_mask: field_mask_pb2.FieldMask = None,
@@ -546,7 +546,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.UpdateSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.UpdateSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.UpdateSecret][google.cloud.secretmanager.v1.SecretManagerService.UpdateSecret].
             secret (:class:`google.cloud.secretmanager_v1.types.Secret`):
@@ -623,7 +623,7 @@ class SecretManagerServiceAsyncClient:
 
     async def delete_secret(
         self,
-        request: service.DeleteSecretRequest = None,
+        request: Union[service.DeleteSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -633,7 +633,7 @@ class SecretManagerServiceAsyncClient:
         r"""Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.DeleteSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.DeleteSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.DeleteSecret][google.cloud.secretmanager.v1.SecretManagerService.DeleteSecret].
             name (:class:`str`):
@@ -688,7 +688,7 @@ class SecretManagerServiceAsyncClient:
 
     async def list_secret_versions(
         self,
-        request: service.ListSecretVersionsRequest = None,
+        request: Union[service.ListSecretVersionsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -700,7 +700,7 @@ class SecretManagerServiceAsyncClient:
         This call does not return secret data.
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.ListSecretVersionsRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.ListSecretVersionsRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.ListSecretVersions][google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
             parent (:class:`str`):
@@ -773,7 +773,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_secret_version(
         self,
-        request: service.GetSecretVersionRequest = None,
+        request: Union[service.GetSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -788,7 +788,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.GetSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.GetSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.GetSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.GetSecretVersion].
             name (:class:`str`):
@@ -854,7 +854,7 @@ class SecretManagerServiceAsyncClient:
 
     async def access_secret_version(
         self,
-        request: service.AccessSecretVersionRequest = None,
+        request: Union[service.AccessSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -870,7 +870,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.AccessSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.AccessSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.AccessSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
             name (:class:`str`):
@@ -946,7 +946,7 @@ class SecretManagerServiceAsyncClient:
 
     async def disable_secret_version(
         self,
-        request: service.DisableSecretVersionRequest = None,
+        request: Union[service.DisableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -963,7 +963,7 @@ class SecretManagerServiceAsyncClient:
         [DISABLED][google.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.DisableSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.DisableSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.DisableSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.DisableSecretVersion].
             name (:class:`str`):
@@ -1026,7 +1026,7 @@ class SecretManagerServiceAsyncClient:
 
     async def enable_secret_version(
         self,
-        request: service.EnableSecretVersionRequest = None,
+        request: Union[service.EnableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1043,7 +1043,7 @@ class SecretManagerServiceAsyncClient:
         [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.EnableSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.EnableSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.EnableSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.EnableSecretVersion].
             name (:class:`str`):
@@ -1106,7 +1106,7 @@ class SecretManagerServiceAsyncClient:
 
     async def destroy_secret_version(
         self,
-        request: service.DestroySecretVersionRequest = None,
+        request: Union[service.DestroySecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1124,7 +1124,7 @@ class SecretManagerServiceAsyncClient:
         and irrevocably destroys the secret data.
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1.types.DestroySecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1.types.DestroySecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.DestroySecretVersion][google.cloud.secretmanager.v1.SecretManagerService.DestroySecretVersion].
             name (:class:`str`):
@@ -1187,7 +1187,7 @@ class SecretManagerServiceAsyncClient:
 
     async def set_iam_policy(
         self,
-        request: iam_policy_pb2.SetIamPolicyRequest = None,
+        request: Union[iam_policy_pb2.SetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1202,7 +1202,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secretmanager.v1.Secret].
 
         Args:
-            request (:class:`google.iam.v1.iam_policy_pb2.SetIamPolicyRequest`):
+            request (Union[google.iam.v1.iam_policy_pb2.SetIamPolicyRequest, dict]):
                 The request object. Request message for `SetIamPolicy`
                 method.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
@@ -1298,7 +1298,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_iam_policy(
         self,
-        request: iam_policy_pb2.GetIamPolicyRequest = None,
+        request: Union[iam_policy_pb2.GetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1309,7 +1309,7 @@ class SecretManagerServiceAsyncClient:
         have a policy set.
 
         Args:
-            request (:class:`google.iam.v1.iam_policy_pb2.GetIamPolicyRequest`):
+            request (Union[google.iam.v1.iam_policy_pb2.GetIamPolicyRequest, dict]):
                 The request object. Request message for `GetIamPolicy`
                 method.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
@@ -1405,7 +1405,7 @@ class SecretManagerServiceAsyncClient:
 
     async def test_iam_permissions(
         self,
-        request: iam_policy_pb2.TestIamPermissionsRequest = None,
+        request: Union[iam_policy_pb2.TestIamPermissionsRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1421,7 +1421,7 @@ class SecretManagerServiceAsyncClient:
         warning.
 
         Args:
-            request (:class:`google.iam.v1.iam_policy_pb2.TestIamPermissionsRequest`):
+            request (Union[google.iam.v1.iam_policy_pb2.TestIamPermissionsRequest, dict]):
                 The request object. Request message for
                 `TestIamPermissions` method.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,

--- a/google/cloud/secretmanager_v1/services/secret_manager_service/client.py
+++ b/google/cloud/secretmanager_v1/services/secret_manager_service/client.py
@@ -391,7 +391,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def list_secrets(
         self,
-        request: service.ListSecretsRequest = None,
+        request: Union[service.ListSecretsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -473,7 +473,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def create_secret(
         self,
-        request: service.CreateSecretRequest = None,
+        request: Union[service.CreateSecretRequest, dict] = None,
         *,
         parent: str = None,
         secret_id: str = None,
@@ -577,7 +577,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def add_secret_version(
         self,
-        request: service.AddSecretVersionRequest = None,
+        request: Union[service.AddSecretVersionRequest, dict] = None,
         *,
         parent: str = None,
         payload: resources.SecretPayload = None,
@@ -664,7 +664,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_secret(
         self,
-        request: service.GetSecretRequest = None,
+        request: Union[service.GetSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -831,7 +831,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def delete_secret(
         self,
-        request: service.DeleteSecretRequest = None,
+        request: Union[service.DeleteSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -896,7 +896,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def list_secret_versions(
         self,
-        request: service.ListSecretVersionsRequest = None,
+        request: Union[service.ListSecretVersionsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -981,7 +981,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_secret_version(
         self,
-        request: service.GetSecretVersionRequest = None,
+        request: Union[service.GetSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1062,7 +1062,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def access_secret_version(
         self,
-        request: service.AccessSecretVersionRequest = None,
+        request: Union[service.AccessSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1144,7 +1144,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def disable_secret_version(
         self,
-        request: service.DisableSecretVersionRequest = None,
+        request: Union[service.DisableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1224,7 +1224,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def enable_secret_version(
         self,
-        request: service.EnableSecretVersionRequest = None,
+        request: Union[service.EnableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1304,7 +1304,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def destroy_secret_version(
         self,
-        request: service.DestroySecretVersionRequest = None,
+        request: Union[service.DestroySecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1385,7 +1385,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def set_iam_policy(
         self,
-        request: iam_policy_pb2.SetIamPolicyRequest = None,
+        request: Union[iam_policy_pb2.SetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1495,7 +1495,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_iam_policy(
         self,
-        request: iam_policy_pb2.GetIamPolicyRequest = None,
+        request: Union[iam_policy_pb2.GetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1601,7 +1601,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def test_iam_permissions(
         self,
-        request: iam_policy_pb2.TestIamPermissionsRequest = None,
+        request: Union[iam_policy_pb2.TestIamPermissionsRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,

--- a/google/cloud/secretmanager_v1/services/secret_manager_service/client.py
+++ b/google/cloud/secretmanager_v1/services/secret_manager_service/client.py
@@ -391,7 +391,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def list_secrets(
         self,
-        request: service.ListSecretsRequest = None,
+        request: Union[service.ListSecretsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -473,7 +473,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def create_secret(
         self,
-        request: service.CreateSecretRequest = None,
+        request: Union[service.CreateSecretRequest, dict] = None,
         *,
         parent: str = None,
         secret_id: str = None,
@@ -577,7 +577,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def add_secret_version(
         self,
-        request: service.AddSecretVersionRequest = None,
+        request: Union[service.AddSecretVersionRequest, dict] = None,
         *,
         parent: str = None,
         payload: resources.SecretPayload = None,
@@ -664,7 +664,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_secret(
         self,
-        request: service.GetSecretRequest = None,
+        request: Union[service.GetSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -742,7 +742,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def update_secret(
         self,
-        request: service.UpdateSecretRequest = None,
+        request: Union[service.UpdateSecretRequest, dict] = None,
         *,
         secret: resources.Secret = None,
         update_mask: field_mask_pb2.FieldMask = None,
@@ -831,7 +831,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def delete_secret(
         self,
-        request: service.DeleteSecretRequest = None,
+        request: Union[service.DeleteSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -896,7 +896,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def list_secret_versions(
         self,
-        request: service.ListSecretVersionsRequest = None,
+        request: Union[service.ListSecretVersionsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -981,7 +981,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_secret_version(
         self,
-        request: service.GetSecretVersionRequest = None,
+        request: Union[service.GetSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1062,7 +1062,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def access_secret_version(
         self,
-        request: service.AccessSecretVersionRequest = None,
+        request: Union[service.AccessSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1144,7 +1144,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def disable_secret_version(
         self,
-        request: service.DisableSecretVersionRequest = None,
+        request: Union[service.DisableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1224,7 +1224,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def enable_secret_version(
         self,
-        request: service.EnableSecretVersionRequest = None,
+        request: Union[service.EnableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1304,7 +1304,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def destroy_secret_version(
         self,
-        request: service.DestroySecretVersionRequest = None,
+        request: Union[service.DestroySecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1385,7 +1385,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def set_iam_policy(
         self,
-        request: iam_policy_pb2.SetIamPolicyRequest = None,
+        request: Union[iam_policy_pb2.SetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1495,7 +1495,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_iam_policy(
         self,
-        request: iam_policy_pb2.GetIamPolicyRequest = None,
+        request: Union[iam_policy_pb2.GetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1601,7 +1601,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def test_iam_permissions(
         self,
-        request: iam_policy_pb2.TestIamPermissionsRequest = None,
+        request: Union[iam_policy_pb2.TestIamPermissionsRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,

--- a/google/cloud/secretmanager_v1/services/secret_manager_service/client.py
+++ b/google/cloud/secretmanager_v1/services/secret_manager_service/client.py
@@ -391,7 +391,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def list_secrets(
         self,
-        request: Union[service.ListSecretsRequest, dict] = None,
+        request: service.ListSecretsRequest = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -473,7 +473,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def create_secret(
         self,
-        request: Union[service.CreateSecretRequest, dict] = None,
+        request: service.CreateSecretRequest = None,
         *,
         parent: str = None,
         secret_id: str = None,
@@ -577,7 +577,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def add_secret_version(
         self,
-        request: Union[service.AddSecretVersionRequest, dict] = None,
+        request: service.AddSecretVersionRequest = None,
         *,
         parent: str = None,
         payload: resources.SecretPayload = None,
@@ -664,7 +664,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_secret(
         self,
-        request: Union[service.GetSecretRequest, dict] = None,
+        request: service.GetSecretRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -742,7 +742,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def update_secret(
         self,
-        request: Union[service.UpdateSecretRequest, dict] = None,
+        request: service.UpdateSecretRequest = None,
         *,
         secret: resources.Secret = None,
         update_mask: field_mask_pb2.FieldMask = None,
@@ -831,7 +831,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def delete_secret(
         self,
-        request: Union[service.DeleteSecretRequest, dict] = None,
+        request: service.DeleteSecretRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -896,7 +896,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def list_secret_versions(
         self,
-        request: Union[service.ListSecretVersionsRequest, dict] = None,
+        request: service.ListSecretVersionsRequest = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -981,7 +981,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_secret_version(
         self,
-        request: Union[service.GetSecretVersionRequest, dict] = None,
+        request: service.GetSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1062,7 +1062,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def access_secret_version(
         self,
-        request: Union[service.AccessSecretVersionRequest, dict] = None,
+        request: service.AccessSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1144,7 +1144,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def disable_secret_version(
         self,
-        request: Union[service.DisableSecretVersionRequest, dict] = None,
+        request: service.DisableSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1224,7 +1224,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def enable_secret_version(
         self,
-        request: Union[service.EnableSecretVersionRequest, dict] = None,
+        request: service.EnableSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1304,7 +1304,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def destroy_secret_version(
         self,
-        request: Union[service.DestroySecretVersionRequest, dict] = None,
+        request: service.DestroySecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1385,7 +1385,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def set_iam_policy(
         self,
-        request: Union[iam_policy_pb2.SetIamPolicyRequest, dict] = None,
+        request: iam_policy_pb2.SetIamPolicyRequest = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1495,7 +1495,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_iam_policy(
         self,
-        request: Union[iam_policy_pb2.GetIamPolicyRequest, dict] = None,
+        request: iam_policy_pb2.GetIamPolicyRequest = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1601,7 +1601,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def test_iam_permissions(
         self,
-        request: Union[iam_policy_pb2.TestIamPermissionsRequest, dict] = None,
+        request: iam_policy_pb2.TestIamPermissionsRequest = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,

--- a/google/cloud/secretmanager_v1beta1/services/secret_manager_service/async_client.py
+++ b/google/cloud/secretmanager_v1beta1/services/secret_manager_service/async_client.py
@@ -188,7 +188,7 @@ class SecretManagerServiceAsyncClient:
 
     async def list_secrets(
         self,
-        request: service.ListSecretsRequest = None,
+        request: Union[service.ListSecretsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -198,7 +198,7 @@ class SecretManagerServiceAsyncClient:
         r"""Lists [Secrets][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.ListSecretsRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.ListSecretsRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.ListSecrets][google.cloud.secrets.v1beta1.SecretManagerService.ListSecrets].
             parent (:class:`str`):
@@ -271,7 +271,7 @@ class SecretManagerServiceAsyncClient:
 
     async def create_secret(
         self,
-        request: service.CreateSecretRequest = None,
+        request: Union[service.CreateSecretRequest, dict] = None,
         *,
         parent: str = None,
         secret_id: str = None,
@@ -285,7 +285,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.CreateSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.CreateSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.CreateSecret][google.cloud.secrets.v1beta1.SecretManagerService.CreateSecret].
             parent (:class:`str`):
@@ -377,7 +377,7 @@ class SecretManagerServiceAsyncClient:
 
     async def add_secret_version(
         self,
-        request: service.AddSecretVersionRequest = None,
+        request: Union[service.AddSecretVersionRequest, dict] = None,
         *,
         parent: str = None,
         payload: resources.SecretPayload = None,
@@ -391,7 +391,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.AddSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.AddSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.AddSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.AddSecretVersion].
             parent (:class:`str`):
@@ -466,7 +466,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_secret(
         self,
-        request: service.GetSecretRequest = None,
+        request: Union[service.GetSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -477,7 +477,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.GetSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.GetSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.GetSecret][google.cloud.secrets.v1beta1.SecretManagerService.GetSecret].
             name (:class:`str`):
@@ -558,7 +558,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.UpdateSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.UpdateSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.UpdateSecret][google.cloud.secrets.v1beta1.SecretManagerService.UpdateSecret].
             secret (:class:`google.cloud.secretmanager_v1beta1.types.Secret`):
@@ -637,7 +637,7 @@ class SecretManagerServiceAsyncClient:
 
     async def delete_secret(
         self,
-        request: service.DeleteSecretRequest = None,
+        request: Union[service.DeleteSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -647,7 +647,7 @@ class SecretManagerServiceAsyncClient:
         r"""Deletes a [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.DeleteSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.DeleteSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.DeleteSecret][google.cloud.secrets.v1beta1.SecretManagerService.DeleteSecret].
             name (:class:`str`):
@@ -704,7 +704,7 @@ class SecretManagerServiceAsyncClient:
 
     async def list_secret_versions(
         self,
-        request: service.ListSecretVersionsRequest = None,
+        request: Union[service.ListSecretVersionsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -716,7 +716,7 @@ class SecretManagerServiceAsyncClient:
         This call does not return secret data.
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.ListSecretVersionsRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.ListSecretVersionsRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.ListSecretVersions][google.cloud.secrets.v1beta1.SecretManagerService.ListSecretVersions].
             parent (:class:`str`):
@@ -791,7 +791,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_secret_version(
         self,
-        request: service.GetSecretVersionRequest = None,
+        request: Union[service.GetSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -806,7 +806,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.GetSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.GetSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.GetSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.GetSecretVersion].
             name (:class:`str`):
@@ -873,7 +873,7 @@ class SecretManagerServiceAsyncClient:
 
     async def access_secret_version(
         self,
-        request: service.AccessSecretVersionRequest = None,
+        request: Union[service.AccessSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -889,7 +889,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.AccessSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.AccessSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.AccessSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.AccessSecretVersion].
             name (:class:`str`):
@@ -962,7 +962,7 @@ class SecretManagerServiceAsyncClient:
 
     async def disable_secret_version(
         self,
-        request: service.DisableSecretVersionRequest = None,
+        request: Union[service.DisableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -978,7 +978,7 @@ class SecretManagerServiceAsyncClient:
         [DISABLED][google.cloud.secrets.v1beta1.SecretVersion.State.DISABLED].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.DisableSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.DisableSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.DisableSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.DisableSecretVersion].
             name (:class:`str`):
@@ -1043,7 +1043,7 @@ class SecretManagerServiceAsyncClient:
 
     async def enable_secret_version(
         self,
-        request: service.EnableSecretVersionRequest = None,
+        request: Union[service.EnableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1059,7 +1059,7 @@ class SecretManagerServiceAsyncClient:
         [ENABLED][google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.EnableSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.EnableSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.EnableSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.EnableSecretVersion].
             name (:class:`str`):
@@ -1124,7 +1124,7 @@ class SecretManagerServiceAsyncClient:
 
     async def destroy_secret_version(
         self,
-        request: service.DestroySecretVersionRequest = None,
+        request: Union[service.DestroySecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1141,7 +1141,7 @@ class SecretManagerServiceAsyncClient:
         and irrevocably destroys the secret data.
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.DestroySecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.DestroySecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.DestroySecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.DestroySecretVersion].
             name (:class:`str`):
@@ -1206,7 +1206,7 @@ class SecretManagerServiceAsyncClient:
 
     async def set_iam_policy(
         self,
-        request: iam_policy.SetIamPolicyRequest = None,
+        request: Union[iam_policy.SetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1221,7 +1221,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (:class:`google.iam.v1.iam_policy_pb2.SetIamPolicyRequest`):
+            request (Union[google.iam.v1.iam_policy_pb2.SetIamPolicyRequest, dict]):
                 The request object. Request message for `SetIamPolicy`
                 method.
 
@@ -1319,7 +1319,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_iam_policy(
         self,
-        request: iam_policy.GetIamPolicyRequest = None,
+        request: Union[iam_policy.GetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1330,7 +1330,7 @@ class SecretManagerServiceAsyncClient:
         have a policy set.
 
         Args:
-            request (:class:`google.iam.v1.iam_policy_pb2.GetIamPolicyRequest`):
+            request (Union[google.iam.v1.iam_policy_pb2.GetIamPolicyRequest, dict]):
                 The request object. Request message for `GetIamPolicy`
                 method.
 
@@ -1428,7 +1428,7 @@ class SecretManagerServiceAsyncClient:
 
     async def test_iam_permissions(
         self,
-        request: iam_policy.TestIamPermissionsRequest = None,
+        request: Union[iam_policy.TestIamPermissionsRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1444,7 +1444,7 @@ class SecretManagerServiceAsyncClient:
         warning.
 
         Args:
-            request (:class:`google.iam.v1.iam_policy_pb2.TestIamPermissionsRequest`):
+            request (Union[google.iam.v1.iam_policy_pb2.TestIamPermissionsRequest, dict]):
                 The request object. Request message for
                 `TestIamPermissions` method.
 

--- a/google/cloud/secretmanager_v1beta1/services/secret_manager_service/async_client.py
+++ b/google/cloud/secretmanager_v1beta1/services/secret_manager_service/async_client.py
@@ -188,7 +188,7 @@ class SecretManagerServiceAsyncClient:
 
     async def list_secrets(
         self,
-        request: service.ListSecretsRequest = None,
+        request: Union[service.ListSecretsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -198,7 +198,7 @@ class SecretManagerServiceAsyncClient:
         r"""Lists [Secrets][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.ListSecretsRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.ListSecretsRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.ListSecrets][google.cloud.secrets.v1beta1.SecretManagerService.ListSecrets].
             parent (:class:`str`):
@@ -271,7 +271,7 @@ class SecretManagerServiceAsyncClient:
 
     async def create_secret(
         self,
-        request: service.CreateSecretRequest = None,
+        request: Union[service.CreateSecretRequest, dict] = None,
         *,
         parent: str = None,
         secret_id: str = None,
@@ -285,7 +285,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.CreateSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.CreateSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.CreateSecret][google.cloud.secrets.v1beta1.SecretManagerService.CreateSecret].
             parent (:class:`str`):
@@ -377,7 +377,7 @@ class SecretManagerServiceAsyncClient:
 
     async def add_secret_version(
         self,
-        request: service.AddSecretVersionRequest = None,
+        request: Union[service.AddSecretVersionRequest, dict] = None,
         *,
         parent: str = None,
         payload: resources.SecretPayload = None,
@@ -391,7 +391,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.AddSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.AddSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.AddSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.AddSecretVersion].
             parent (:class:`str`):
@@ -466,7 +466,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_secret(
         self,
-        request: service.GetSecretRequest = None,
+        request: Union[service.GetSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -477,7 +477,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.GetSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.GetSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.GetSecret][google.cloud.secrets.v1beta1.SecretManagerService.GetSecret].
             name (:class:`str`):
@@ -546,7 +546,7 @@ class SecretManagerServiceAsyncClient:
 
     async def update_secret(
         self,
-        request: service.UpdateSecretRequest = None,
+        request: Union[service.UpdateSecretRequest, dict] = None,
         *,
         secret: resources.Secret = None,
         update_mask: field_mask.FieldMask = None,
@@ -558,7 +558,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.UpdateSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.UpdateSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.UpdateSecret][google.cloud.secrets.v1beta1.SecretManagerService.UpdateSecret].
             secret (:class:`google.cloud.secretmanager_v1beta1.types.Secret`):
@@ -637,7 +637,7 @@ class SecretManagerServiceAsyncClient:
 
     async def delete_secret(
         self,
-        request: service.DeleteSecretRequest = None,
+        request: Union[service.DeleteSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -647,7 +647,7 @@ class SecretManagerServiceAsyncClient:
         r"""Deletes a [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.DeleteSecretRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.DeleteSecretRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.DeleteSecret][google.cloud.secrets.v1beta1.SecretManagerService.DeleteSecret].
             name (:class:`str`):
@@ -704,7 +704,7 @@ class SecretManagerServiceAsyncClient:
 
     async def list_secret_versions(
         self,
-        request: service.ListSecretVersionsRequest = None,
+        request: Union[service.ListSecretVersionsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -716,7 +716,7 @@ class SecretManagerServiceAsyncClient:
         This call does not return secret data.
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.ListSecretVersionsRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.ListSecretVersionsRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.ListSecretVersions][google.cloud.secrets.v1beta1.SecretManagerService.ListSecretVersions].
             parent (:class:`str`):
@@ -791,7 +791,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_secret_version(
         self,
-        request: service.GetSecretVersionRequest = None,
+        request: Union[service.GetSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -806,7 +806,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.GetSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.GetSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.GetSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.GetSecretVersion].
             name (:class:`str`):
@@ -873,7 +873,7 @@ class SecretManagerServiceAsyncClient:
 
     async def access_secret_version(
         self,
-        request: service.AccessSecretVersionRequest = None,
+        request: Union[service.AccessSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -889,7 +889,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.AccessSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.AccessSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.AccessSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.AccessSecretVersion].
             name (:class:`str`):
@@ -962,7 +962,7 @@ class SecretManagerServiceAsyncClient:
 
     async def disable_secret_version(
         self,
-        request: service.DisableSecretVersionRequest = None,
+        request: Union[service.DisableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -978,7 +978,7 @@ class SecretManagerServiceAsyncClient:
         [DISABLED][google.cloud.secrets.v1beta1.SecretVersion.State.DISABLED].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.DisableSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.DisableSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.DisableSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.DisableSecretVersion].
             name (:class:`str`):
@@ -1043,7 +1043,7 @@ class SecretManagerServiceAsyncClient:
 
     async def enable_secret_version(
         self,
-        request: service.EnableSecretVersionRequest = None,
+        request: Union[service.EnableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1059,7 +1059,7 @@ class SecretManagerServiceAsyncClient:
         [ENABLED][google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED].
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.EnableSecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.EnableSecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.EnableSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.EnableSecretVersion].
             name (:class:`str`):
@@ -1124,7 +1124,7 @@ class SecretManagerServiceAsyncClient:
 
     async def destroy_secret_version(
         self,
-        request: service.DestroySecretVersionRequest = None,
+        request: Union[service.DestroySecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1141,7 +1141,7 @@ class SecretManagerServiceAsyncClient:
         and irrevocably destroys the secret data.
 
         Args:
-            request (:class:`google.cloud.secretmanager_v1beta1.types.DestroySecretVersionRequest`):
+            request (Union[google.cloud.secretmanager_v1beta1.types.DestroySecretVersionRequest, dict]):
                 The request object. Request message for
                 [SecretManagerService.DestroySecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.DestroySecretVersion].
             name (:class:`str`):
@@ -1206,7 +1206,7 @@ class SecretManagerServiceAsyncClient:
 
     async def set_iam_policy(
         self,
-        request: iam_policy.SetIamPolicyRequest = None,
+        request: Union[iam_policy.SetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1221,7 +1221,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (:class:`google.iam.v1.iam_policy_pb2.SetIamPolicyRequest`):
+            request (Union[google.iam.v1.iam_policy_pb2.SetIamPolicyRequest, dict]):
                 The request object. Request message for `SetIamPolicy`
                 method.
 
@@ -1319,7 +1319,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_iam_policy(
         self,
-        request: iam_policy.GetIamPolicyRequest = None,
+        request: Union[iam_policy.GetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1330,7 +1330,7 @@ class SecretManagerServiceAsyncClient:
         have a policy set.
 
         Args:
-            request (:class:`google.iam.v1.iam_policy_pb2.GetIamPolicyRequest`):
+            request (Union[google.iam.v1.iam_policy_pb2.GetIamPolicyRequest, dict]):
                 The request object. Request message for `GetIamPolicy`
                 method.
 
@@ -1428,7 +1428,7 @@ class SecretManagerServiceAsyncClient:
 
     async def test_iam_permissions(
         self,
-        request: iam_policy.TestIamPermissionsRequest = None,
+        request: Union[iam_policy.TestIamPermissionsRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1444,7 +1444,7 @@ class SecretManagerServiceAsyncClient:
         warning.
 
         Args:
-            request (:class:`google.iam.v1.iam_policy_pb2.TestIamPermissionsRequest`):
+            request (Union[google.iam.v1.iam_policy_pb2.TestIamPermissionsRequest, dict]):
                 The request object. Request message for
                 `TestIamPermissions` method.
 

--- a/google/cloud/secretmanager_v1beta1/services/secret_manager_service/async_client.py
+++ b/google/cloud/secretmanager_v1beta1/services/secret_manager_service/async_client.py
@@ -188,7 +188,7 @@ class SecretManagerServiceAsyncClient:
 
     async def list_secrets(
         self,
-        request: Union[service.ListSecretsRequest, dict] = None,
+        request: service.ListSecretsRequest = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -198,7 +198,7 @@ class SecretManagerServiceAsyncClient:
         r"""Lists [Secrets][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1beta1.types.ListSecretsRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1beta1.types.ListSecretsRequest`):
                 The request object. Request message for
                 [SecretManagerService.ListSecrets][google.cloud.secrets.v1beta1.SecretManagerService.ListSecrets].
             parent (:class:`str`):
@@ -271,7 +271,7 @@ class SecretManagerServiceAsyncClient:
 
     async def create_secret(
         self,
-        request: Union[service.CreateSecretRequest, dict] = None,
+        request: service.CreateSecretRequest = None,
         *,
         parent: str = None,
         secret_id: str = None,
@@ -285,7 +285,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1beta1.types.CreateSecretRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1beta1.types.CreateSecretRequest`):
                 The request object. Request message for
                 [SecretManagerService.CreateSecret][google.cloud.secrets.v1beta1.SecretManagerService.CreateSecret].
             parent (:class:`str`):
@@ -377,7 +377,7 @@ class SecretManagerServiceAsyncClient:
 
     async def add_secret_version(
         self,
-        request: Union[service.AddSecretVersionRequest, dict] = None,
+        request: service.AddSecretVersionRequest = None,
         *,
         parent: str = None,
         payload: resources.SecretPayload = None,
@@ -391,7 +391,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1beta1.types.AddSecretVersionRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1beta1.types.AddSecretVersionRequest`):
                 The request object. Request message for
                 [SecretManagerService.AddSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.AddSecretVersion].
             parent (:class:`str`):
@@ -466,7 +466,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_secret(
         self,
-        request: Union[service.GetSecretRequest, dict] = None,
+        request: service.GetSecretRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -477,7 +477,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1beta1.types.GetSecretRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1beta1.types.GetSecretRequest`):
                 The request object. Request message for
                 [SecretManagerService.GetSecret][google.cloud.secrets.v1beta1.SecretManagerService.GetSecret].
             name (:class:`str`):
@@ -546,7 +546,7 @@ class SecretManagerServiceAsyncClient:
 
     async def update_secret(
         self,
-        request: Union[service.UpdateSecretRequest, dict] = None,
+        request: service.UpdateSecretRequest = None,
         *,
         secret: resources.Secret = None,
         update_mask: field_mask.FieldMask = None,
@@ -558,7 +558,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1beta1.types.UpdateSecretRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1beta1.types.UpdateSecretRequest`):
                 The request object. Request message for
                 [SecretManagerService.UpdateSecret][google.cloud.secrets.v1beta1.SecretManagerService.UpdateSecret].
             secret (:class:`google.cloud.secretmanager_v1beta1.types.Secret`):
@@ -637,7 +637,7 @@ class SecretManagerServiceAsyncClient:
 
     async def delete_secret(
         self,
-        request: Union[service.DeleteSecretRequest, dict] = None,
+        request: service.DeleteSecretRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -647,7 +647,7 @@ class SecretManagerServiceAsyncClient:
         r"""Deletes a [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1beta1.types.DeleteSecretRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1beta1.types.DeleteSecretRequest`):
                 The request object. Request message for
                 [SecretManagerService.DeleteSecret][google.cloud.secrets.v1beta1.SecretManagerService.DeleteSecret].
             name (:class:`str`):
@@ -704,7 +704,7 @@ class SecretManagerServiceAsyncClient:
 
     async def list_secret_versions(
         self,
-        request: Union[service.ListSecretVersionsRequest, dict] = None,
+        request: service.ListSecretVersionsRequest = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -716,7 +716,7 @@ class SecretManagerServiceAsyncClient:
         This call does not return secret data.
 
         Args:
-            request (Union[google.cloud.secretmanager_v1beta1.types.ListSecretVersionsRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1beta1.types.ListSecretVersionsRequest`):
                 The request object. Request message for
                 [SecretManagerService.ListSecretVersions][google.cloud.secrets.v1beta1.SecretManagerService.ListSecretVersions].
             parent (:class:`str`):
@@ -791,7 +791,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_secret_version(
         self,
-        request: Union[service.GetSecretVersionRequest, dict] = None,
+        request: service.GetSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -806,7 +806,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1beta1.types.GetSecretVersionRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1beta1.types.GetSecretVersionRequest`):
                 The request object. Request message for
                 [SecretManagerService.GetSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.GetSecretVersion].
             name (:class:`str`):
@@ -873,7 +873,7 @@ class SecretManagerServiceAsyncClient:
 
     async def access_secret_version(
         self,
-        request: Union[service.AccessSecretVersionRequest, dict] = None,
+        request: service.AccessSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -889,7 +889,7 @@ class SecretManagerServiceAsyncClient:
         [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1beta1.types.AccessSecretVersionRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1beta1.types.AccessSecretVersionRequest`):
                 The request object. Request message for
                 [SecretManagerService.AccessSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.AccessSecretVersion].
             name (:class:`str`):
@@ -962,7 +962,7 @@ class SecretManagerServiceAsyncClient:
 
     async def disable_secret_version(
         self,
-        request: Union[service.DisableSecretVersionRequest, dict] = None,
+        request: service.DisableSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -978,7 +978,7 @@ class SecretManagerServiceAsyncClient:
         [DISABLED][google.cloud.secrets.v1beta1.SecretVersion.State.DISABLED].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1beta1.types.DisableSecretVersionRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1beta1.types.DisableSecretVersionRequest`):
                 The request object. Request message for
                 [SecretManagerService.DisableSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.DisableSecretVersion].
             name (:class:`str`):
@@ -1043,7 +1043,7 @@ class SecretManagerServiceAsyncClient:
 
     async def enable_secret_version(
         self,
-        request: Union[service.EnableSecretVersionRequest, dict] = None,
+        request: service.EnableSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1059,7 +1059,7 @@ class SecretManagerServiceAsyncClient:
         [ENABLED][google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED].
 
         Args:
-            request (Union[google.cloud.secretmanager_v1beta1.types.EnableSecretVersionRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1beta1.types.EnableSecretVersionRequest`):
                 The request object. Request message for
                 [SecretManagerService.EnableSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.EnableSecretVersion].
             name (:class:`str`):
@@ -1124,7 +1124,7 @@ class SecretManagerServiceAsyncClient:
 
     async def destroy_secret_version(
         self,
-        request: Union[service.DestroySecretVersionRequest, dict] = None,
+        request: service.DestroySecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1141,7 +1141,7 @@ class SecretManagerServiceAsyncClient:
         and irrevocably destroys the secret data.
 
         Args:
-            request (Union[google.cloud.secretmanager_v1beta1.types.DestroySecretVersionRequest, dict]):
+            request (:class:`google.cloud.secretmanager_v1beta1.types.DestroySecretVersionRequest`):
                 The request object. Request message for
                 [SecretManagerService.DestroySecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.DestroySecretVersion].
             name (:class:`str`):
@@ -1206,7 +1206,7 @@ class SecretManagerServiceAsyncClient:
 
     async def set_iam_policy(
         self,
-        request: Union[iam_policy.SetIamPolicyRequest, dict] = None,
+        request: iam_policy.SetIamPolicyRequest = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1221,7 +1221,7 @@ class SecretManagerServiceAsyncClient:
         [Secret][google.cloud.secrets.v1beta1.Secret].
 
         Args:
-            request (Union[google.iam.v1.iam_policy_pb2.SetIamPolicyRequest, dict]):
+            request (:class:`google.iam.v1.iam_policy_pb2.SetIamPolicyRequest`):
                 The request object. Request message for `SetIamPolicy`
                 method.
 
@@ -1319,7 +1319,7 @@ class SecretManagerServiceAsyncClient:
 
     async def get_iam_policy(
         self,
-        request: Union[iam_policy.GetIamPolicyRequest, dict] = None,
+        request: iam_policy.GetIamPolicyRequest = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1330,7 +1330,7 @@ class SecretManagerServiceAsyncClient:
         have a policy set.
 
         Args:
-            request (Union[google.iam.v1.iam_policy_pb2.GetIamPolicyRequest, dict]):
+            request (:class:`google.iam.v1.iam_policy_pb2.GetIamPolicyRequest`):
                 The request object. Request message for `GetIamPolicy`
                 method.
 
@@ -1428,7 +1428,7 @@ class SecretManagerServiceAsyncClient:
 
     async def test_iam_permissions(
         self,
-        request: Union[iam_policy.TestIamPermissionsRequest, dict] = None,
+        request: iam_policy.TestIamPermissionsRequest = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1444,7 +1444,7 @@ class SecretManagerServiceAsyncClient:
         warning.
 
         Args:
-            request (Union[google.iam.v1.iam_policy_pb2.TestIamPermissionsRequest, dict]):
+            request (:class:`google.iam.v1.iam_policy_pb2.TestIamPermissionsRequest`):
                 The request object. Request message for
                 `TestIamPermissions` method.
 

--- a/google/cloud/secretmanager_v1beta1/services/secret_manager_service/client.py
+++ b/google/cloud/secretmanager_v1beta1/services/secret_manager_service/client.py
@@ -372,7 +372,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def list_secrets(
         self,
-        request: service.ListSecretsRequest = None,
+        request: Union[service.ListSecretsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -456,7 +456,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def create_secret(
         self,
-        request: service.CreateSecretRequest = None,
+        request: Union[service.CreateSecretRequest, dict] = None,
         *,
         parent: str = None,
         secret_id: str = None,
@@ -563,7 +563,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def add_secret_version(
         self,
-        request: service.AddSecretVersionRequest = None,
+        request: Union[service.AddSecretVersionRequest, dict] = None,
         *,
         parent: str = None,
         payload: resources.SecretPayload = None,
@@ -653,7 +653,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_secret(
         self,
-        request: service.GetSecretRequest = None,
+        request: Union[service.GetSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -826,7 +826,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def delete_secret(
         self,
-        request: service.DeleteSecretRequest = None,
+        request: Union[service.DeleteSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -894,7 +894,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def list_secret_versions(
         self,
-        request: service.ListSecretVersionsRequest = None,
+        request: Union[service.ListSecretVersionsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -982,7 +982,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_secret_version(
         self,
-        request: service.GetSecretVersionRequest = None,
+        request: Union[service.GetSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1065,7 +1065,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def access_secret_version(
         self,
-        request: service.AccessSecretVersionRequest = None,
+        request: Union[service.AccessSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1146,7 +1146,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def disable_secret_version(
         self,
-        request: service.DisableSecretVersionRequest = None,
+        request: Union[service.DisableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1228,7 +1228,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def enable_secret_version(
         self,
-        request: service.EnableSecretVersionRequest = None,
+        request: Union[service.EnableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1310,7 +1310,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def destroy_secret_version(
         self,
-        request: service.DestroySecretVersionRequest = None,
+        request: Union[service.DestroySecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1393,7 +1393,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def set_iam_policy(
         self,
-        request: iam_policy.SetIamPolicyRequest = None,
+        request: Union[iam_policy.SetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1505,7 +1505,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_iam_policy(
         self,
-        request: iam_policy.GetIamPolicyRequest = None,
+        request: Union[iam_policy.GetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1613,7 +1613,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def test_iam_permissions(
         self,
-        request: iam_policy.TestIamPermissionsRequest = None,
+        request: Union[iam_policy.TestIamPermissionsRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,

--- a/google/cloud/secretmanager_v1beta1/services/secret_manager_service/client.py
+++ b/google/cloud/secretmanager_v1beta1/services/secret_manager_service/client.py
@@ -372,7 +372,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def list_secrets(
         self,
-        request: Union[service.ListSecretsRequest, dict] = None,
+        request: service.ListSecretsRequest = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -456,7 +456,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def create_secret(
         self,
-        request: Union[service.CreateSecretRequest, dict] = None,
+        request: service.CreateSecretRequest = None,
         *,
         parent: str = None,
         secret_id: str = None,
@@ -563,7 +563,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def add_secret_version(
         self,
-        request: Union[service.AddSecretVersionRequest, dict] = None,
+        request: service.AddSecretVersionRequest = None,
         *,
         parent: str = None,
         payload: resources.SecretPayload = None,
@@ -653,7 +653,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_secret(
         self,
-        request: Union[service.GetSecretRequest, dict] = None,
+        request: service.GetSecretRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -734,7 +734,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def update_secret(
         self,
-        request: Union[service.UpdateSecretRequest, dict] = None,
+        request: service.UpdateSecretRequest = None,
         *,
         secret: resources.Secret = None,
         update_mask: field_mask.FieldMask = None,
@@ -826,7 +826,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def delete_secret(
         self,
-        request: Union[service.DeleteSecretRequest, dict] = None,
+        request: service.DeleteSecretRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -894,7 +894,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def list_secret_versions(
         self,
-        request: Union[service.ListSecretVersionsRequest, dict] = None,
+        request: service.ListSecretVersionsRequest = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -982,7 +982,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_secret_version(
         self,
-        request: Union[service.GetSecretVersionRequest, dict] = None,
+        request: service.GetSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1065,7 +1065,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def access_secret_version(
         self,
-        request: Union[service.AccessSecretVersionRequest, dict] = None,
+        request: service.AccessSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1146,7 +1146,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def disable_secret_version(
         self,
-        request: Union[service.DisableSecretVersionRequest, dict] = None,
+        request: service.DisableSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1228,7 +1228,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def enable_secret_version(
         self,
-        request: Union[service.EnableSecretVersionRequest, dict] = None,
+        request: service.EnableSecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1310,7 +1310,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def destroy_secret_version(
         self,
-        request: Union[service.DestroySecretVersionRequest, dict] = None,
+        request: service.DestroySecretVersionRequest = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1393,7 +1393,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def set_iam_policy(
         self,
-        request: Union[iam_policy.SetIamPolicyRequest, dict] = None,
+        request: iam_policy.SetIamPolicyRequest = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1505,7 +1505,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_iam_policy(
         self,
-        request: Union[iam_policy.GetIamPolicyRequest, dict] = None,
+        request: iam_policy.GetIamPolicyRequest = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1613,7 +1613,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def test_iam_permissions(
         self,
-        request: Union[iam_policy.TestIamPermissionsRequest, dict] = None,
+        request: iam_policy.TestIamPermissionsRequest = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,

--- a/google/cloud/secretmanager_v1beta1/services/secret_manager_service/client.py
+++ b/google/cloud/secretmanager_v1beta1/services/secret_manager_service/client.py
@@ -372,7 +372,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def list_secrets(
         self,
-        request: service.ListSecretsRequest = None,
+        request: Union[service.ListSecretsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -456,7 +456,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def create_secret(
         self,
-        request: service.CreateSecretRequest = None,
+        request: Union[service.CreateSecretRequest, dict] = None,
         *,
         parent: str = None,
         secret_id: str = None,
@@ -563,7 +563,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def add_secret_version(
         self,
-        request: service.AddSecretVersionRequest = None,
+        request: Union[service.AddSecretVersionRequest, dict] = None,
         *,
         parent: str = None,
         payload: resources.SecretPayload = None,
@@ -653,7 +653,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_secret(
         self,
-        request: service.GetSecretRequest = None,
+        request: Union[service.GetSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -734,7 +734,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def update_secret(
         self,
-        request: service.UpdateSecretRequest = None,
+        request: Union[service.UpdateSecretRequest, dict] = None,
         *,
         secret: resources.Secret = None,
         update_mask: field_mask.FieldMask = None,
@@ -826,7 +826,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def delete_secret(
         self,
-        request: service.DeleteSecretRequest = None,
+        request: Union[service.DeleteSecretRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -894,7 +894,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def list_secret_versions(
         self,
-        request: service.ListSecretVersionsRequest = None,
+        request: Union[service.ListSecretVersionsRequest, dict] = None,
         *,
         parent: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -982,7 +982,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_secret_version(
         self,
-        request: service.GetSecretVersionRequest = None,
+        request: Union[service.GetSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1065,7 +1065,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def access_secret_version(
         self,
-        request: service.AccessSecretVersionRequest = None,
+        request: Union[service.AccessSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1146,7 +1146,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def disable_secret_version(
         self,
-        request: service.DisableSecretVersionRequest = None,
+        request: Union[service.DisableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1228,7 +1228,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def enable_secret_version(
         self,
-        request: service.EnableSecretVersionRequest = None,
+        request: Union[service.EnableSecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1310,7 +1310,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def destroy_secret_version(
         self,
-        request: service.DestroySecretVersionRequest = None,
+        request: Union[service.DestroySecretVersionRequest, dict] = None,
         *,
         name: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1393,7 +1393,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def set_iam_policy(
         self,
-        request: iam_policy.SetIamPolicyRequest = None,
+        request: Union[iam_policy.SetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1505,7 +1505,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def get_iam_policy(
         self,
-        request: iam_policy.GetIamPolicyRequest = None,
+        request: Union[iam_policy.GetIamPolicyRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
@@ -1613,7 +1613,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 
     def test_iam_permissions(
         self,
-        request: iam_policy.TestIamPermissionsRequest = None,
+        request: Union[iam_policy.TestIamPermissionsRequest, dict] = None,
         *,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,

--- a/owlbot.py
+++ b/owlbot.py
@@ -46,7 +46,7 @@ s.move(templated_files, excludes=[".coveragerc"])  # microgenerator has a good .
 
 s.replace(
     "google/**/*client.py",
-    "request: ([^\[]*) = None",
+    "request: ([^U]*?) = None",
     "request: Union[\g<1>, dict] = None",
     
 )

--- a/owlbot.py
+++ b/owlbot.py
@@ -39,6 +39,23 @@ templated_files = common.py_library(
 )
 s.move(templated_files, excludes=[".coveragerc"])  # microgenerator has a good .coveragerc file
 
+# Fix type annotations for requests
+# Not needed once generator version is >=0.51.1
+# Generator version: https://github.com/googleapis/googleapis/blob/master/WORKSPACE#L227
+# Fix in generator: https://github.com/googleapis/gapic-generator-python/commit/49205d99dd440690b838c8eb3f6a695f35b061c2
+
+s.replace(
+    "google/**/*client.py",
+    "request: (.*) = None",
+    "request: Union[\g<1>, dict] = None",
+    
+)
+s.replace(
+    "google/**/*client.py",
+    "request \(:class:`(.*)`\):",
+    "request (Union[\g<1>, dict]):"
+)
+
 # ----------------------------------------------------------------------------
 # Samples templates
 # ----------------------------------------------------------------------------

--- a/owlbot.py
+++ b/owlbot.py
@@ -46,7 +46,7 @@ s.move(templated_files, excludes=[".coveragerc"])  # microgenerator has a good .
 
 s.replace(
     "google/**/*client.py",
-    "request: (.*) = None",
+    "request: ([^\[]*) = None",
     "request: Union[\g<1>, dict] = None",
     
 )


### PR DESCRIPTION
The generator version cannot currently be changed since googleapis is frozen. This PR manually applies the [type annotation fix](https://github.com/googleapis/gapic-generator-python/commit/49205d99dd440690b838c8eb3f6a695f35b061c2) for requests.

Fixes #90 🦕
