### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "secretmanager",
     "name_pretty": "Cloud Secret Manager",
     "product_documentation": "https://cloud.google.com/secret-manager/",
-    "client_documentation": "https://googleapis.dev/python/secretmanager/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/secretmanager/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Python Client for Secret Manager API
    :target: https://pypi.org/project/google-cloud-secret-manager/
 
 .. _Secret Manager API: https://cloud.google.com/secret-manager
-.. _Client Library Documentation: https://googleapis.dev/python/secretmanager/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/secretmanager/latest
 .. _Product Documentation:  https://cloud.google.com/secret-manager
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.