### PR TITLE
fix(deps): move libcst to extras

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,10 +17,10 @@ The 2.0.0 release requires Python 3.6+.
 
 Methods expect request objects. We provide a script that will convert most common use cases.
 
-* Install the library
+* Install the library with the `libcst` extra.
 
 ```py
-python3 -m pip install google-cloud-secret-manager
+python3 -m pip install google-cloud-secret-manager[libcst]
 ```
 
 * The script `fixup_secretmanager_v1_keywords.py` is shipped with the library. It expects

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ dependencies = [
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     "proto-plus >= 1.4.0",
-    "libcst >= 0.2.5",
 ]
+extras = {"libcst": "libcst >= 0.2.5"}
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 
@@ -77,6 +77,7 @@ setuptools.setup(
     packages=packages,
     namespace_packages=namespaces,
     install_requires=dependencies,
+    extras_require=extras,
     python_requires=">=3.6",
     scripts=[
         "scripts/fixup_secretmanager_v1_keywords.py",


### PR DESCRIPTION
`libcst` is only needed to run the fixup script
