### PR TITLE
fix: wrong package name google-cloud-secretmanager

### DIFF
--- a/google/cloud/secretmanager_v1/services/secret_manager_service/async_client.py
+++ b/google/cloud/secretmanager_v1/services/secret_manager_service/async_client.py
@@ -1891,7 +1891,7 @@ class SecretManagerServiceAsyncClient:
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
         gapic_version=pkg_resources.get_distribution(
-            "google-cloud-secretmanager",
+            "google-cloud-secret-manager",
         ).version,
     )
 except pkg_resources.DistributionNotFound:

--- a/google/cloud/secretmanager_v1/services/secret_manager_service/client.py
+++ b/google/cloud/secretmanager_v1/services/secret_manager_service/client.py
@@ -2137,7 +2137,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
         gapic_version=pkg_resources.get_distribution(
-            "google-cloud-secretmanager",
+            "google-cloud-secret-manager",
         ).version,
     )
 except pkg_resources.DistributionNotFound:

--- a/google/cloud/secretmanager_v1/services/secret_manager_service/transports/base.py
+++ b/google/cloud/secretmanager_v1/services/secret_manager_service/transports/base.py
@@ -33,7 +33,7 @@ from google.cloud.secretmanager_v1.types import resources, service
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
         gapic_version=pkg_resources.get_distribution(
-            "google-cloud-secretmanager",
+            "google-cloud-secret-manager",
         ).version,
     )
 except pkg_resources.DistributionNotFound:

--- a/google/cloud/secretmanager_v1beta1/services/secret_manager_service/async_client.py
+++ b/google/cloud/secretmanager_v1beta1/services/secret_manager_service/async_client.py
@@ -1568,7 +1568,7 @@ class SecretManagerServiceAsyncClient:
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
         gapic_version=pkg_resources.get_distribution(
-            "google-cloud-secretmanager",
+            "google-cloud-secret-manager",
         ).version,
     )
 except pkg_resources.DistributionNotFound:

--- a/google/cloud/secretmanager_v1beta1/services/secret_manager_service/client.py
+++ b/google/cloud/secretmanager_v1beta1/services/secret_manager_service/client.py
@@ -1780,7 +1780,7 @@ class SecretManagerServiceClient(metaclass=SecretManagerServiceClientMeta):
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
         gapic_version=pkg_resources.get_distribution(
-            "google-cloud-secretmanager",
+            "google-cloud-secret-manager",
         ).version,
     )
 except pkg_resources.DistributionNotFound:

--- a/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/base.py
+++ b/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/base.py
@@ -33,7 +33,7 @@ from google.cloud.secretmanager_v1beta1.types import resources, service
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
         gapic_version=pkg_resources.get_distribution(
-            "google-cloud-secretmanager",
+            "google-cloud-secret-manager",
         ).version,
     )
 except pkg_resources.DistributionNotFound:

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_access_secret_version_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_access_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_AccessSecretVersion_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_access_secret_version_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_access_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_AccessSecretVersion_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_add_secret_version_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_add_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_AddSecretVersion_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_add_secret_version_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_add_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_AddSecretVersion_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_create_secret_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_create_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_CreateSecret_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_create_secret_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_create_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_CreateSecret_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_delete_secret_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_delete_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_DeleteSecret_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_delete_secret_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_delete_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_DeleteSecret_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_destroy_secret_version_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_destroy_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_DestroySecretVersion_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_destroy_secret_version_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_destroy_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_DestroySecretVersion_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_disable_secret_version_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_disable_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_DisableSecretVersion_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_disable_secret_version_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_disable_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_DisableSecretVersion_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_enable_secret_version_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_enable_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_EnableSecretVersion_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_enable_secret_version_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_enable_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_EnableSecretVersion_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_iam_policy_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_iam_policy_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_GetIamPolicy_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_iam_policy_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_iam_policy_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_GetIamPolicy_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_GetSecret_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_GetSecret_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_version_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_GetSecretVersion_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_version_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_GetSecretVersion_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secret_versions_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secret_versions_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_ListSecretVersions_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secret_versions_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secret_versions_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_ListSecretVersions_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_ListSecrets_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_ListSecrets_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_set_iam_policy_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_set_iam_policy_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_SetIamPolicy_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_set_iam_policy_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_set_iam_policy_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_SetIamPolicy_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_test_iam_permissions_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_test_iam_permissions_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_TestIamPermissions_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_test_iam_permissions_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_test_iam_permissions_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_TestIamPermissions_sync]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_update_secret_async.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_update_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_UpdateSecret_async]

--- a/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_update_secret_sync.py
+++ b/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_update_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1_generated_SecretManagerService_UpdateSecret_sync]


### PR DESCRIPTION

Fixes #323 - wrong package name in pip install
Fixes #324 - wrong package name in get_distribution 🦕
