### PR TITLE
samples: move google_crc32c to be in sample

### DIFF
--- a/samples/snippets/add_secret_version.py
+++ b/samples/snippets/add_secret_version.py
@@ -19,10 +19,8 @@ specified payload to an existing secret.
 
 import argparse
 
-import google_crc32c
-
-
 # [START secretmanager_add_secret_version]
+import google_crc32c
 def add_secret_version(project_id, secret_id, payload):
     """
     Add a new secret version to the given secret with the provided payload.

--- a/samples/snippets/add_secret_version.py
+++ b/samples/snippets/add_secret_version.py
@@ -21,6 +21,8 @@ import argparse
 
 # [START secretmanager_add_secret_version]
 import google_crc32c
+
+
 def add_secret_version(project_id, secret_id, payload):
     """
     Add a new secret version to the given secret with the provided payload.


### PR DESCRIPTION
Importing google_crc32c requirement was not clear in sample.